### PR TITLE
Fixed cookie cutter setup bug for installing environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,5 +4,5 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 root = ".."
-write_to = "dp-proj-llmeo/version.py"
+write_to = "llmeo/version.py"
 

--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,5 @@ setup(
         'Programming Language :: Python :: 3.10',
     ],
     license='MIT',
+    version="0.1.0",
 )


### PR DESCRIPTION
**📌 Description / 🚀 Changes**
Fixed a bug that prevented users from successfully running pip install -e ..
The issue was traced to misconfigured pyproject.toml and setup.py files, likely carried over from the main repository’s cookiecutter template.

This PR updates both files to ensure the environment can be set up correctly using editable install.

**✅ What’s Fixed**
	•	Corrected pyproject.toml and setup.py configurations
	•	`write_to = "llmeo/version.py"`